### PR TITLE
Fixed the 'cdpoke' function

### DIFF
--- a/sw/src/wib_3asic.cc
+++ b/sw/src/wib_3asic.cc
@@ -28,7 +28,7 @@ bool WIB_3ASIC::script_extra(const vector<string> &tokens) {
         string fast(tokens[1]);
         if (fast == "reset") {
             FEMB_3ASIC::fast_cmd(FAST_CMD_RESET);
-        } else if (cmd == "act") {
+        } else if (fast == "act") {
             FEMB_3ASIC::fast_cmd(FAST_CMD_ACT);
         } else if (fast == "sync") {
             FEMB_3ASIC::fast_cmd(FAST_CMD_SYNC);

--- a/sw/wib_client.py
+++ b/sw/wib_client.py
@@ -103,7 +103,7 @@ def script(args):
         req.file = False
     else:
         print('Executing remote script...')
-        req.script = args.filename
+        req.script = bytes(args.filename, 'utf-8')
         req.file = True
     wib.send_command(req,rep)
     print('Successful:',rep.success)

--- a/sw/wib_client.py
+++ b/sw/wib_client.py
@@ -210,7 +210,7 @@ cdfastcmd_parser.add_argument('command',choices=['reset', 'act', 'sync', 'edge',
 def cdfastcmd(args):
     fast_cmds = { 'reset':1, 'act':2, 'sync':4, 'edge':8, 'idle':16, 'edge_act':32 }
     req = wibpb.CDFastCmd()
-    req.cmd = fast_cmds[argument.command]
+    req.cmd = fast_cmds[args.command]
     rep = wibpb.Empty()
     wib.send_command(req,rep)
     print('Fast command sent')

--- a/sw/wib_client.py
+++ b/sw/wib_client.py
@@ -178,6 +178,7 @@ def cdpeek(args):
     rep = wibpb.CDRegValue()
     req.femb_idx = args.femb_idx
     req.coldata_idx = args.coldata_idx
+    req.chip_addr = args.chip_addr
     req.reg_page = args.reg_page
     req.reg_addr = args.reg_addr
     wib.send_command(req,rep)

--- a/sw/wib_client.py
+++ b/sw/wib_client.py
@@ -197,6 +197,7 @@ def cdpoke(args):
     rep = wibpb.CDRegValue()
     req.femb_idx = args.femb_idx
     req.coldata_idx = args.coldata_idx
+    req.chip_addr = args.chip_addr
     req.reg_page = args.reg_page
     req.reg_addr = args.reg_addr
     req.data = args.data


### PR DESCRIPTION
`cdpoke` and `cdpeek` was missing a single parameter when taking the command line argument to the ZeroMQ req object.

Also made a change where the protobuf definition didn't allow the remote script option with a string. Converting the string to bytes so that it satisfies the proto file is confirmed to work.