### PR TITLE
Calibration Updates

### DIFF
--- a/sw/src/femb_3asic.cc
+++ b/sw/src/femb_3asic.cc
@@ -135,6 +135,7 @@ bool FEMB_3ASIC::setup_calib_manual(uint8_t sn, uint8_t stage) {
     //See COLDADC datasheet
     if (stage > 6) return false; //invalid
     for (uint8_t i = 4; i <= 11; i++) { // Each COLDATA is now directly accessed through the second argument
+        res &= i2c_write_verify(0, i, 1, 0x80+41, 0x00);
         switch (sn) {
             case 0: {
                 const uint8_t cal_stages = (stage+1) & 0x7;
@@ -158,6 +159,7 @@ bool FEMB_3ASIC::setup_calib_manual(uint8_t sn, uint8_t stage) {
                 res &= i2c_write_verify(0, i, 1, 0x80+45, 0x00);
                 res &= i2c_write_verify(0, i, 1, 0x80+46, 0x00);
         }
+        res &= i2c_write_verify(0, i, 1, 0x80+41, 0x01);
     }
     return res;
 }

--- a/sw/src/femb_3asic.cc
+++ b/sw/src/femb_3asic.cc
@@ -113,9 +113,23 @@ bool FEMB_3ASIC::configure_coldadc(bool cold, bool test_pattern, coldadc_conf *a
     return res;
 }
 
+bool FEMB_3ASIC::setup_calib_auto() {
+    bool res = true;
+    for (uint8_t j = 4; j <= 11; j++) { // For each COLADC attached to COLDATA
+        glog.log("Starting calibration on COLDADC:%i!\n",j);
+        res &= i2c_write_verify(0, j, 1, 0x80+41, 0x00);
+        res &= i2c_write_verify(0, j, 1, 0x80+31, 0x03);
+        usleep(500000);
+        res &= i2c_write_verify(0, j, 1, 0x80+31, 0x00);
+        res &= i2c_write_verify(0, j, 1, 0x80+41, 0x01);
+        glog.log("Done calibration on COLDADC:%i!\n",j);
+    }
+    return res;
+}
+
 // must run sn = 0 first, then 1,2,3; any other sn resets
 // must run stage 6 first, ..., stage 0
-bool FEMB_3ASIC::setup_calib(uint8_t sn, uint8_t stage) {
+bool FEMB_3ASIC::setup_calib_manual(uint8_t sn, uint8_t stage) {
     bool res = true;
     //Based on algorithm from Dave Christian
     //See COLDADC datasheet

--- a/sw/src/femb_3asic.cc
+++ b/sw/src/femb_3asic.cc
@@ -162,6 +162,23 @@ bool FEMB_3ASIC::setup_calib_manual(uint8_t sn, uint8_t stage) {
     return res;
 }
 
+void FEMB_3ASIC::dump_calib_constants() {
+    for (uint8_t j = 4; j <= 11; j++) { // For each COLADC attached to COLDATA
+        for (uint8_t caladdr = 0x00; caladdr <= 0x1D; caladdr++) {
+            glog.log("Calibration constant %02x (W0, ADC0) on COLDADC %i: %02x\n",caladdr,j,i2c_read(0, j, 1, caladdr));
+        }
+        for (uint8_t caladdr = 0x20; caladdr <= 0x3D; caladdr++) {
+            glog.log("Calibration constant %02x (W2, ADC0) on COLDADC %i: %02x\n",caladdr,j,i2c_read(0, j, 1, caladdr));
+        }
+        for (uint8_t caladdr = 0x40; caladdr <= 0x5D; caladdr++) {
+            glog.log("Calibration constant %02x (W0, ADC1) on COLDADC %i: %02x\n",caladdr,j,i2c_read(0, j, 1, caladdr));
+        }
+        for (uint8_t caladdr = 0x60; caladdr <= 0x7D; caladdr++) {
+            glog.log("Calibration constant %02x (W2, ADC1) on COLDADC %i: %02x\n",caladdr,j,i2c_read(0, j, 1, caladdr));
+        }
+    }
+}
+
 bool FEMB_3ASIC::store_calib(const uint16_t w0_vals[8][2], const uint16_t w2_vals[8][2], uint8_t stage) {
     bool res = true;
     //Based on algorithm from Dave Christian

--- a/sw/src/femb_3asic.h
+++ b/sw/src/femb_3asic.h
@@ -96,6 +96,7 @@ public:
 
     // for manual calibration 
     bool setup_calib_manual(uint8_t sn, uint8_t stage);
+    void dump_calib_constants();
     bool store_calib(const uint16_t w0_vals[8][2], const uint16_t w2_vals[8][2], uint8_t stage);
     
     // for setting the FMB_CONTROL_WORD

--- a/sw/src/femb_3asic.h
+++ b/sw/src/femb_3asic.h
@@ -92,8 +92,10 @@ public:
     bool read_spi_status(); // requires ACT_SAVE_STATUS first
     void log_spi_status(); // requires ACT_SAVE_STATUS first
     
+    bool setup_calib_auto();
+
     // for manual calibration 
-    bool setup_calib(uint8_t sn, uint8_t stage);
+    bool setup_calib_manual(uint8_t sn, uint8_t stage);
     bool store_calib(const uint16_t w0_vals[8][2], const uint16_t w2_vals[8][2], uint8_t stage);
     
     // for setting the FMB_CONTROL_WORD

--- a/sw/src/wib_3asic.cc
+++ b/sw/src/wib_3asic.cc
@@ -436,10 +436,12 @@ bool WIB_3ASIC::configure_wib(const wib::ConfigureWIB &conf) {
 bool WIB_3ASIC::calibrate() {
     for (int i = 0; i < 4; i++) { //femb
         if (!frontend_power[i]) continue; // skip FEMBs that are off
+        glog.log("Calibrating FEMB %i\n",i);
         if (!femb[i]->setup_calib_auto()) {
             glog.log("Failed to setup FEMB %i\n",i);
             return false;
         }
+        femb[i]->dump_calib_constants();
     }
     return true;
 }

--- a/sw/src/wib_3asic.cc
+++ b/sw/src/wib_3asic.cc
@@ -446,7 +446,7 @@ bool WIB_3ASIC::calibrate() {
     return true;
 }
 
-/*bool WIB_3ASIC::calibrate_manual() { // Old way of manual calibration, when register 31 didn't function properly
+bool WIB_3ASIC::calibrate_manual() { // Old way of manual calibration, when register 31 didn't function properly
     channel_data link0, link1;
     glog.log("Calibrating COLDADCs\n");
     for (int stage = 6; stage >= 0; stage--) {
@@ -513,5 +513,8 @@ bool WIB_3ASIC::calibrate() {
         }
     }
     glog.log("Calibration completed\n");
+    for (int i = 0; i < 4; i++) {
+        femb[i]->dump_calib_constants();
+    }
     return true;
-}*/
+}

--- a/sw/src/wib_3asic.cc
+++ b/sw/src/wib_3asic.cc
@@ -434,6 +434,17 @@ bool WIB_3ASIC::configure_wib(const wib::ConfigureWIB &conf) {
 }
 
 bool WIB_3ASIC::calibrate() {
+    for (int i = 0; i < 4; i++) { //femb
+        if (!frontend_power[i]) continue; // skip FEMBs that are off
+        if (!femb[i]->setup_calib_auto()) {
+            glog.log("Failed to setup FEMB %i\n",i);
+            return false;
+        }
+    }
+    return true;
+}
+
+/*bool WIB_3ASIC::calibrate_manual() { // Old way of manual calibration, when register 31 didn't function properly
     channel_data link0, link1;
     glog.log("Calibrating COLDADCs\n");
     for (int stage = 6; stage >= 0; stage--) {
@@ -443,7 +454,7 @@ bool WIB_3ASIC::calibrate() {
             //put the COLDADCs in forcing mode for calibration
             for (int i = 0; i < 4; i++) {
                 if (!frontend_power[i]) continue; // skip FEMBs that are off
-                if (!femb[i]->setup_calib(sn,stage)) {
+                if (!femb[i]->setup_calib_manual(sn,stage)) {
                     glog.log("Failed to setup stage %i S%i measurement for FEMB %i\n",stage,sn,i);
                     return false;
                 }
@@ -501,4 +512,4 @@ bool WIB_3ASIC::calibrate() {
     }
     glog.log("Calibration completed\n");
     return true;
-}
+}*/

--- a/sw/src/wib_3asic.h
+++ b/sw/src/wib_3asic.h
@@ -27,8 +27,10 @@ public:
     // Configure the frontend for this WIB
     virtual bool configure_wib(const wib::ConfigureWIB &conf);
     
-    // Calibrate the COLDADCs manually
     virtual bool calibrate();
+
+    // Calibrate the COLDADCs manually
+    virtual bool calibrate_manual();
     
 protected:
 


### PR DESCRIPTION
Switch to using new auto-calibration done on the chip. Dumps calibration constants into log after calibration. Keep the old manual calibration method after fixing it to be used for comparison. This is currently in use at the CERN coldbox tests.