### PR TITLE
DAQ Context field functionality

### DIFF
--- a/sw/src/wib_3asic.h
+++ b/sw/src/wib_3asic.h
@@ -57,6 +57,9 @@ protected:
     // Set value for delay before each EDGE command for synchronization
     bool set_edge_delay(uint8_t edge_delay);
   
+    // Set 8-bit context ID field for DAQ readout
+    bool set_context_field(uint8_t context);
+  
     // Set WIB frame channel mapping
     bool set_channel_map(int detector_type);
 


### PR DESCRIPTION
Added basic function to set DAQ context field to pulser DAC value when pulser is active.